### PR TITLE
Organization用のプロフィールを作成

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,106 @@
+![1](https://github.com/triC-tmu/triC-tmu/assets/56724676/3d04433a-68db-4b25-a839-dc5aeceead32)
+
+
+<h1 align="center">triC / TMU 競技プログラミングサークル</h1>
+
+<h4 align="center">A Tokyo Metropolitan University Competitive Programming Club <a href="https://twitter.com/triC_PR" target="_blank">triC</a>.</h4>
+
+<p align="center">
+  <a href="https://atcoder.jp/users/igeee?contestType=algo"><img src="https://badgen.org/img/atcoder/igeee/rating/algorithm?style=flat" alt="Rating" /></a>
+  <a href="https://atcoder.jp/users/kya?contestType=algo"><img src="https://badgen.org/img/atcoder/kya/rating/algorithm?style=flat" alt="Rating" /></a>
+  <a href="https://atcoder.jp/users/nattonato?contestType=algo"><img src="https://badgen.org/img/atcoder/nattonato/rating/algorithm?style=flat" alt="Rating" /></a>
+  <a href="https://atcoder.jp/users/Ayutaso?contestType=algo"><img src="https://badgen.org/img/atcoder/Ayutaso/rating/algorithm?style=flat" alt="Rating" /></a>
+</p>
+
+<p align="center">
+  <a href="https://twitter.com/triC_PR">
+    <img alt="Twitter: triC_PR" src="https://img.shields.io/twitter/follow/triC_PR.svg?style=social" target="_blank" />
+  </a>
+  <img src="https://discordapp.com/api/guilds/679637170398822455/widget.png?style=shield" alt="Discord Shield"/>
+</p>
+
+<p align="center">
+  <a href="#about">About</a> •
+  <a href="#activity">Activity</a> •
+  <a href="#achievements">Achievements</a> •
+  <a href="#introduce-member">Introduce Member</a> •
+  <a href="#join-us">Join Us</a> •
+  <a href="#contact-us">Contact Us</a> •
+  <a href="#%EF%B8%8Ffaq%EF%B8%8F">FAQ</a>
+</p>
+
+## 📌About📌
+triC(トリック)は東京都立大学の競技プログラミングサークルです。
+triCは競技プログラミングに興味のある学生が集まったコミュニティで、現在はB1からM1までの15人ほどが所属しています！
+
+### [サークル説明会]()
+新歓期間中はサークル説明会を以下の日程で開催予定ですので少しでも興味を持った方はぜひ説明会にご参加ください！
+
+説明会について詳しくは[2024年度triC新歓説明会]()をご覧ください！
+
+<!-- 
+|        | 日付 | 時間 | 場所       |
+| ------ | ---- | ---- | ---------- |
+| 第一回 | 未定 | 未定 | オンライン |
+| 第二回 | 未定 | 未定 | オンライン |
+| 第三回 | 未定 | 未定 | オンライン |
+| 第四回 | 未定 | 未定 | オンライン |
+
+※ 上記説明会の日程が都合が合わない場合でもご連絡いただければ調整が可能です。<br />
+※ 説明会に参加していない場合でもtriCへの参加は可能です。
+-->
+
+### [初心者向けプログラミング勉強会]()
+2024年は[初心者向けプログラミングの勉強会]()を実施する予定です。
+大学でプログラミングをやってみたい方、授業より早くプログラミングを勉強したい方など興味のある方はぜひお気軽にご参加ください！
+
+### 競技プログラミングとは？
+
+詳しくは[こちら]()をご覧ください！
+
+## 🎓Activity🎓
+日々の活動としてはVirtural Contestの開催と不定期の勉強会をしています。
+
+[AtCoder](https://atcoder.jp/?lang=ja)のコンテスト後には集まって感想会もしています！
+活動への参加は完全に任意で、勉強会やコンテスト、その他のサークル活動に参加するかどうかは各メンバーの自由です。
+
+さらに、チーム戦のプログラミングコンテストが開催される時にはサークル内の有志でチームを組んで練習などもしています！
+
+
+
+## 🏆Achievements🏆
+
+<img src="https://github.com/triC-tmu/triC-tmu/assets/56724676/bc9dd6b8-2701-4732-a739-4783458de23c" align="right" width="300"/>
+
+triCではICPCという大会に毎年参加しており、結成間もないサークルながらアジア地区大会に3回出場しています！(右: 昨年のICPCアジア地区大会の様子)
+- ICPC 2023 Asia Yokohama Reagional 出場
+- PG Battle 2023 アシスト賞 受賞
+- ICPC 2022 Asia Yokohama Reagional 出場
+- ICPC 2019 Asia Yokohama Reagional 出場
+
+
+## 📕Introduce Member📕
+メンバー紹介(個人の活動紹介とか？Twitter張るとか?)
+
+## 📣Join Us📣
+triCに入りたい！と思った方はぜひその旨
+[X公式アカウント](https://twitter.com/triC_PR)のDMまでご連絡ください！
+
+## 📮Contact Us📮
+興味がある方はぜひご連絡ください！
+[X公式アカウント](https://twitter.com/triC_PR)のDMまでご連絡ください！
+
+## 🏷️FAQ🏷️
+
+#### Q. 競技プログラミングの経験がないのですが、参加しても大丈夫ですか？
+
+A. はい。
+
+#### Q. 活動日や活動場所は？
+
+A. 任意参加のVirtual Contestをオンラインで月曜、木曜の21時からやっています。他に不定期でオンラインやオフライン(主に南大沢キャンパス図書館)で勉強会を行っています。
+
+#### Q. 参加費は必要ですか？
+
+A. いいえ。
+


### PR DESCRIPTION
# 変更内容
GitHub Organization の機能で `.github` というレポジトリを作成するとその中の `profile/README.md` が自動でトップページに表示される機能があるので, それ用に `profile/README.md` を作成しました。
PR をマージ後, rename すれば自動で表示されると思います。

不必要であれば適当に close してもらって大丈夫です。


# 参考
- [パブリック Organization プロフィールの README の追加](https://docs.github.com/ja/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme)

**横山研の GitHub**
![image](https://github.com/triC-tmu/triC-tmu/assets/51400692/bb3364fc-3b25-4cf5-a11a-a2586d59febe)
